### PR TITLE
Lovense: reorganize documentation

### DIFF
--- a/stpihkal/hardware/lovense.md
+++ b/stpihkal/hardware/lovense.md
@@ -423,6 +423,34 @@ _Return Example_
 OK;
 ```
 
+#### Set Rotation Speed and Direction
+
+Sets the rotation speed and direction at once. Takes integers values from 0-20.
+
+_Availability_: Nora
+
+```
+RotateClockwise:10;
+```
+
+Sets rotation direction to clockwise and speed to 10 (50%).
+
+_Return Example_
+```
+OK;
+```
+
+```
+RotateAntiClockwise:2;
+```
+
+Sets rotation direction to anti-clockwise and speed to 2 (10%).
+
+_Return Example_
+```
+OK;
+```
+
 #### Set Absolute Air Level
 
 Changes the inflation level of the Max toy. Takes integer values from 0-5.

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -7,68 +7,6 @@ undergone multiple hardware and firmware revisions since. The protocol changes
 between versions are usually minor, but for clarity: unless otherwise indicated,
 this document refers to the latest of hardware and firmware for a given model.
 
-## Supported Commands by Model
-
-| Command                   | Ambi | Domi | Edge | Hush | Lush | Max | Nora | Osci | Quake |
-| ------------------------- | :--: | :--: | :--: | :--: | :--: | :-: | :--: | :--: | :---: |
-| [`Air:In:𝛘`]              |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
-| [`Air:Level:𝛘`]           |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
-| [`Air:Out:𝛘`]             |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
-| [`ALight:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`AutoSwith:𝛘:𝛄`]         |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Battery`]               |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
-| [`DeviceType`]            |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
-| [`GetALight`]             |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetAS`]                 |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetBatch`]              |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
-| [`GetLevel`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetLight`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetPatten:𝛘`]           |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetPatten`]             |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Light:𝛘`]               |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`PowerOff`]              |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |   ❔   |
-| [`Preset:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Rotate:𝛘`]              |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
-| [`RotateAntiClockwise:𝛘`] |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
-| [`RotateChange`]          |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
-| [`RotateClockwise:𝛘`]     |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
-| [`SetLevel`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`SetLevel`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`StartMove:𝛘`]           |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
-| [`Status:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❌   |
-| [`StopMove:𝛘`]            |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
-| [`Vibrate:𝛘`]             | All  |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Vibrate𝛘:𝛄`]            |  ❔   |  ❔   |  ✔️  |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |  ✔️   |
-
-[`Air:In:𝛘`]: #Air:In:𝛘
-[`Air:Level:𝛘`]: #Air:Level:𝛘
-[`Air:Out:𝛘`]: #Air:Out:𝛘
-[`ALight:𝛘`]: #ALight:𝛘
-[`AutoSwith:𝛘:𝛄`]: #AutoSwith:𝛘:𝛄
-[`Battery`]: #Battery
-[`DeviceType`]: #DeviceType
-[`GetALight`]: #GetALight
-[`GetAS`]: #GetAS
-[`GetBatch`]: #GetBatch
-[`GetLevel`]: #GetLevel
-[`GetLight`]: #GetLight
-[`GetPatten:𝛘`]: #GetPatten:𝛘
-[`GetPatten`]: #GetPatten
-[`Light:𝛘`]: #Light:𝛘
-[`PowerOff`]: #PowerOff
-[`Preset:𝛘`]: #Preset:𝛘
-[`Rotate:𝛘`]: #Rotate:𝛘
-[`RotateAntiClockwise:𝛘`]: #RotateAntiClockwise:𝛘
-[`RotateChange`]: #RotateChange
-[`RotateClockwise:𝛘`]: #RotateClockwise:𝛘
-[`SetLevel`]: #SetLevel
-[`SetLevel`]: #SetLevel
-[`StartMove:𝛘`]: #StartMove:𝛘
-[`Status:𝛘`]: #Status:𝛘
-[`StopMove:𝛘`]: #StopMove:𝛘
-[`Vibrate:𝛘`]: #Vibrate:𝛘
-[`Vibrate𝛘:𝛄`]: #Vibrate:𝛘:𝛄
-
 ## Bluetooth Details
 
 While all Lovense toys use the same protocol, they can communicate over
@@ -153,6 +91,122 @@ over the serial port is in quotes to denote communication, but should not be
 sent using quotes if you are implementing your own version of this protocol.
 Commands with ":x" mean that the x should be replaced with a number, the range
 of which is mentioned in the description.
+
+## Commands
+
+### Support by Model
+
+| Command                   | Ambi | Domi | Edge | Hush | Lush | Max | Nora | Osci | Quake |
+| ------------------------- | :--: | :--: | :--: | :--: | :--: | :-: | :--: | :--: | :---: |
+| [`Air:In:𝛘`]              |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
+| [`Air:Level:𝛘`]           |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
+| [`Air:Out:𝛘`]             |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
+| [`ALight:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`AutoSwith:𝛘:𝛄`]         |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Battery`]               |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
+| [`DeviceType`]            |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
+| [`GetALight`]             |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetAS`]                 |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetBatch`]              |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
+| [`GetLevel`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetLight`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetPatten:𝛘`]           |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetPatten`]             |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Light:𝛘`]               |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`PowerOff`]              |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |   ❔   |
+| [`Preset:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Rotate:𝛘`]              |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
+| [`RotateAntiClockwise:𝛘`] |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
+| [`RotateChange`]          |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
+| [`RotateClockwise:𝛘`]     |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
+| [`SetLevel`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`StartMove:𝛘`]           |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
+| [`Status:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❌   |
+| [`StopMove:𝛘`]            |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
+| [`Vibrate:𝛘`]             | All  |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Vibrate𝛘:𝛄`]            |  ❔   |  ❔   |  ✔️  |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |  ✔️   |
+
+[`Air:In:𝛘`]: #AirIn𝛘
+[`Air:Level:𝛘`]: #AirLevel𝛘
+[`Air:Out:𝛘`]: #AirOut𝛘
+[`ALight:𝛘`]: #ALight𝛘
+[`AutoSwith:𝛘:𝛄`]: #AutoSwith𝛘𝛄
+[`Battery`]: #Battery
+[`DeviceType`]: #DeviceType
+[`GetALight`]: #GetALight
+[`GetAS`]: #GetAS
+[`GetBatch`]: #GetBatch
+[`GetLevel`]: #GetLevel
+[`GetLight`]: #GetLight
+[`GetPatten:𝛘`]: #GetPatten𝛘
+[`GetPatten`]: #GetPatten
+[`Light:𝛘`]: #Light𝛘
+[`PowerOff`]: #PowerOff
+[`Preset:𝛘`]: #Preset𝛘
+[`Rotate:𝛘`]: #Rotate𝛘
+[`RotateAntiClockwise:𝛘`]: #RotateAntiClockwise𝛘
+[`RotateChange`]: #RotateChange
+[`RotateClockwise:𝛘`]: #RotateClockwise𝛘
+[`SetLevel`]: #SetLevel
+[`StartMove:𝛘`]: #StartMove:𝛘
+[`Status:𝛘`]: #Status:𝛘
+[`StopMove:𝛘`]: #StopMove:𝛘
+[`Vibrate:𝛘`]: #Vibrate:𝛘
+[`Vibrate𝛘:𝛄`]: #Vibrate:𝛘:𝛄
+
+### `Air:In:𝛘`
+
+### `Air:Level:𝛘`
+
+### `Air:Out:𝛘`
+
+### `ALight:𝛘`
+
+### `AutoSwith:𝛘:𝛄`
+
+### `Battery`
+
+### `DeviceType`
+
+### `GetALight`
+
+### `GetAS`
+
+### `GetBatch`
+
+### `GetLevel`
+
+### `GetLight`
+
+### `GetPatten:𝛘`
+
+### `GetPatten`
+
+### `Light:𝛘`
+
+### `PowerOff`
+
+### `Preset:𝛘`
+
+### `Rotate:𝛘`
+
+### `RotateAntiClockwise:𝛘`
+
+### `RotateChange`
+
+### `RotateClockwise:𝛘`
+
+### `SetLevel`
+
+### `StartMove:𝛘`
+
+### `Status:𝛘`
+
+### `StopMove:𝛘`
+
+### `Vibrate:𝛘`
+
+### `Vibrate𝛘:𝛄`
 
 #### Get Device Information
 

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -21,6 +21,12 @@ meaningful return value will respond with either the string `OK` or the original
 command string, while invalid commands will respond with either the string `ERR`
 or the original command string prefixed with `UNKNOWN,`.
 
+Some response messages are prefixed to indicate which command they are in
+response to, but some are not. Typically, this is not a problem because as they
+are unambiguously in response to the most recent command. However, certain
+commands such as [`StartMove:𝛘`] can send responses interwoven with those from
+other commands, requiring more care.
+
 Here is an example session, with whitespace added to distinguish transmitter and
 receiver.
 
@@ -109,8 +115,41 @@ to identify the model in the toy's Bluetooth name and `DeviceType` response.
 ## Commands
 
 Note that there are many inconsistencies of formatting, spelling, and
-capitalization between the commands and responses. Be sure to copy the values
-exactly as the protocol expects.
+capitalization within the commands and responses. Make sure you are copying
+these values exactly as the protocol expect them.
+
+<!-- universal -->
+
+[`Battery`]: #Battery
+[`DeviceType`]: #DeviceType
+[`GetBatch`]: #GetBatch
+[`PowerOff`]: #PowerOff
+[`Vibrate:𝛘`]: #Vibrate:𝛘
+
+<!-- device-specific -->
+
+[`Air:In:𝛘`]: #AirIn𝛘
+[`Air:Level:𝛘`]: #AirLevel𝛘
+[`Air:Out:𝛘`]: #AirOut𝛘
+[`ALight:𝛘`]: #ALight𝛘
+[`AutoSwith:𝛘:𝛄`]: #AutoSwith𝛘𝛄
+[`GetAlight`]: #GetAlight
+[`GetAS`]: #GetAS
+[`GetLevel`]: #GetLevel
+[`GetLight`]: #GetLight
+[`GetPatten:𝛘`]: #GetPatten𝛘
+[`GetPatten`]: #GetPatten
+[`Light:𝛘`]: #Light𝛘
+[`Preset:𝛘`]: #Preset𝛘
+[`Rotate:𝛘`]: #Rotate𝛘
+[`RotateAntiClockwise:𝛘`]: #RotateAntiClockwise𝛘
+[`RotateChange`]: #RotateChange
+[`RotateClockwise:𝛘`]: #RotateClockwise𝛘
+[`SetLevel`]: #SetLevel
+[`StartMove:𝛘`]: #StartMove:𝛘
+[`Status:𝛘`]: #Status:𝛘
+[`StopMove:𝛘`]: #StopMove:𝛘
+[`Vibrate𝛘:𝛄`]: #Vibrate:𝛘:𝛄
 
 ### Compatibility Matrix
 
@@ -144,34 +183,6 @@ exactly as the protocol expects.
 | [`Status:𝛘`]              |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
 | [`StopMove:𝛘`]            |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
 | [`Vibrate𝛘:𝛄`]            |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
-
-[`Battery`]: #Battery
-[`DeviceType`]: #DeviceType
-[`GetBatch`]: #GetBatch
-[`PowerOff`]: #PowerOff
-[`Vibrate:𝛘`]: #Vibrate:𝛘
-[`Air:In:𝛘`]: #AirIn𝛘
-[`Air:Level:𝛘`]: #AirLevel𝛘
-[`Air:Out:𝛘`]: #AirOut𝛘
-[`ALight:𝛘`]: #ALight𝛘
-[`AutoSwith:𝛘:𝛄`]: #AutoSwith𝛘𝛄
-[`GetAlight`]: #GetAlight
-[`GetAS`]: #GetAS
-[`GetLevel`]: #GetLevel
-[`GetLight`]: #GetLight
-[`GetPatten:𝛘`]: #GetPatten𝛘
-[`GetPatten`]: #GetPatten
-[`Light:𝛘`]: #Light𝛘
-[`Preset:𝛘`]: #Preset𝛘
-[`Rotate:𝛘`]: #Rotate𝛘
-[`RotateAntiClockwise:𝛘`]: #RotateAntiClockwise𝛘
-[`RotateChange`]: #RotateChange
-[`RotateClockwise:𝛘`]: #RotateClockwise𝛘
-[`SetLevel`]: #SetLevel
-[`StartMove:𝛘`]: #StartMove:𝛘
-[`Status:𝛘`]: #Status:𝛘
-[`StopMove:𝛘`]: #StopMove:𝛘
-[`Vibrate𝛘:𝛄`]: #Vibrate:𝛘:𝛄
 
 ### `Battery`
 

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -180,6 +180,21 @@ Commands for Lovense toys follows these rules:
 
 ### `Battery`
 
+Returns the battery level of the toy as an integer percentage from 0-100.
+
+Some toys will also prepend an `s` character (such as `s99`) to indicate when
+they are active (i.e. when a vibrator motor is turned on).
+
+#### Example
+
+```
+Battery;
+
+  85;
+```
+
+Denotes 85% battery remaining.
+
 ### `DeviceType`
 
 Returns the toy's model identifier, firmware version, and Bluetooth MAC address,
@@ -249,29 +264,6 @@ address of `00:82:05:9A:D3:BD`.
 ### `Vibrate:𝛘`
 
 ### `Vibrate𝛘:𝛄`
-
-#### Get Battery Level
-
-Returns the battery level of the toy as an integer percentage from 0-100.
-
-Some toys will prepend an `s` character (such as `s99`) to indicate that when
-they are active (i.e. when a vibrator motor is turned on).
-
-_Availability:_ All toys
-
-_Command Format_
-
-```
-Battery;
-```
-
-_Return Example_
-
-```
-85;
-```
-
-Denotes 85% battery remaining.
 
 #### Turn Off Power
 
@@ -804,28 +796,4 @@ _Return Example_
 
 ```
 OK;
-```
-
-## Related Projects and Links
-
-The applications and repositories below contain implementations of the Lovense
-communications protocol, or have relevant information about the
-hardware/firmware.
-
-- Buttplug C# (All toys):
-  [https://github.com/metafetish/buttplug-csharp](https://github.com/metafetish/buttplug-csharp)
-- Buttplug JS (All toys):
-  [https://github.com/metafetish/buttplug-js](https://github.com/metafetish/buttplug-js)
-- lovesense-rs (Rust, Max/Nora only):
-  [https://github.com/metafetish/lovesense-rs](https://github.com/metafetish/lovesense-rs)
-- lovesense-py (Python, Max/Nora only):
-  [https://github.com/metafetish/lovesense-py](https://github.com/metafetish/lovesense-py)
-- Max/MSP patch (Max/MSP, Max/Nora only):
-  [https://github.com/metafetish/lovesense-max](https://github.com/metafetish/lovesense-max)
-- Node.js Library (Max/Nora only):
-  [https://github.com/metafetish/lovesense-js](https://github.com/metafetish/lovesense-js)
-- WebBluetooth JS Library/Demo (Hush only):
-  [https://github.com/metafetish/lovesense-hush-js-demo](https://github.com/metafetish/lovesense-hush-js-demo)
-
-```
 ```

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -2,15 +2,47 @@
 
 ## Background
 
-Lovense has been manufacturing toys since 2011. Many of their toy models have
-undergone multiple hardware and firmware revisions since. The protocol changes
-between versions are usually minor, but for clarity: unless otherwise indicated,
-this document refers to the latest of hardware and firmware for a given model.
+[Lovense](https://www.lovense.com/) has been manufacturing wireless Bluetooth
+sex toys since 2011. Many of their models lines have undergone multiple hardware
+and firmware revisions in that time. The protocol changes are usually minor, but
+for clarity: unless otherwise indicated, this document refers to the latest
+hardware and firmware revisions for each model.
 
 ## Bluetooth Details
 
-While all Lovense toys use the same protocol, they can communicate over
-Bluetooth differently, depending on when they were released.
+Lovense toys use a serial-style RPC protocol over Bluetooth, with commands
+messages sent from the client and result messages sent from the toy. Messages
+are terminated by `;` semicolons. Supported commands will always recieve one or
+more results, unless that command itself is to disconnect/shut down the toy.
+Here is an example session (with whitespace added to indicate sender/reciever).
+
+```
+DeviceType;
+
+  C:11:0082059AD3BD;
+
+GetBatch;
+
+  190124;
+
+Battery;
+
+  95;
+
+GetPatten;
+
+  P:01234;
+
+GetPatten:4;
+
+  P4:1/5:000042003720;
+  P4:2/5:000002436658;
+  P4:3/5:997339993001;
+  P4:4/5:291111115111;
+  P4:5/5:1110000000;
+
+PowerOff;
+```
 
 ### Bluetooth 2.0 Toys
 
@@ -96,35 +128,35 @@ of which is mentioned in the description.
 
 ### Support by Model
 
-| Command                   | Ambi | Domi | Edge | Hush | Lush | Max | Nora | Osci | Quake |
-| ------------------------- | :--: | :--: | :--: | :--: | :--: | :-: | :--: | :--: | :---: |
-| [`Air:In:𝛘`]              |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
-| [`Air:Level:𝛘`]           |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
-| [`Air:Out:𝛘`]             |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
-| [`ALight:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`AutoSwith:𝛘:𝛄`]         |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Battery`]               |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
-| [`DeviceType`]            |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
-| [`GetALight`]             |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetAS`]                 |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetBatch`]              |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
-| [`GetLevel`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetLight`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetPatten:𝛘`]           |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetPatten`]             |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Light:𝛘`]               |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`PowerOff`]              |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |   ❔   |
-| [`Preset:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Rotate:𝛘`]              |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
-| [`RotateAntiClockwise:𝛘`] |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
-| [`RotateChange`]          |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
-| [`RotateClockwise:𝛘`]     |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
-| [`SetLevel`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`StartMove:𝛘`]           |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
-| [`Status:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❌   |
-| [`StopMove:𝛘`]            |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
-| [`Vibrate:𝛘`]             | All  |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Vibrate𝛘:𝛄`]            |  ❔   |  ❔   |  ✔️  |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |  ✔️   |
+| Command                   | Ambi | Diamo | Domi | Edge | Ferri | Hush | Lush | Max | Nora | Osci | Quake |
+| ------------------------- | :--: | :---: | :--: | :--: | :---: | :--: | :--: | :-: | :--: | :--: | :---: |
+| [`Air:In:𝛘`]              |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
+| [`Air:Level:𝛘`]           |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
+| [`Air:Out:𝛘`]             |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
+| [`ALight:𝛘`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`AutoSwith:𝛘:𝛄`]         |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Battery`]               |  ✔️  |   ❔   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
+| [`DeviceType`]            |  ✔️  |   ❔   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
+| [`GetALight`]             |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetAS`]                 |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetBatch`]              |  ✔️  |   ❔   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
+| [`GetLevel`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetLight`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetPatten:𝛘`]           |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetPatten`]             |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Light:𝛘`]               |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`PowerOff`]              |  ✔️  |   ❔   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |   ❔   |
+| [`Preset:𝛘`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Rotate:𝛘`]              |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
+| [`RotateAntiClockwise:𝛘`] |  ❌   |   ❌   |  ❌   |  ❌   |   ❌   |  ❌   |  ✔️  |  ❌  |  ❌   |      |       |
+| [`RotateChange`]          |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
+| [`RotateClockwise:𝛘`]     |  ❌   |   ❌   |  ❌   |  ❌   |   ❌   |  ❌   |  ✔️  |  ❌  |  ❌   |      |       |
+| [`SetLevel`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`StartMove:𝛘`]           |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
+| [`Status:𝛘`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❌   |
+| [`StopMove:𝛘`]            |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
+| [`Vibrate:𝛘`]             | All  |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Vibrate𝛘:𝛄`]            |  ❔   |   ❔   |  ❔   |  ✔️  |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |  ✔️   |
 
 [`Air:In:𝛘`]: #AirIn𝛘
 [`Air:Level:𝛘`]: #AirLevel𝛘
@@ -762,8 +794,11 @@ Domi response using one-digit part indices:
 _Return Example_
 
 ```
-P4:1/5:000042003720; P4:2/5:000002436658; P4:3/5:997339993001;
-P4:4/5:291111115111; P4:5/5:1110000000;
+P4:1/5:000042003720;
+P4:2/5:000002436658;
+P4:3/5:997339993001;
+P4:4/5:291111115111;
+P4:5/5:1110000000;
 ```
 
 Lush 2 response using two-digit part indices:

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -17,8 +17,8 @@ one response, unless that command itself shuts down the toy first.
 
 Depending on the model and firmware versions, valid commands that do not have
 meaningful return value will respond with either the string `OK` or the original
-command string, while invalid commands will respond with either `ERR` or
-`UNKNOWN,` followed by the original command string.
+command string, while invalid commands will respond with either the string `ERR`
+or the original command string prefixed with `UNKNOWN,`.
 
 Here is an example session, with whitespace added to distinguish transmitter and
 reciever.

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -116,17 +116,9 @@ Commands for Lovense toys follows these rules:
 - Commands that do not return a context specific value will return "OK;" on
   success, "ERR;" on error.
 
-### Command List
-
-The following is the known command table for all toys. Anything send or received
-over the serial port is in quotes to denote communication, but should not be
-sent using quotes if you are implementing your own version of this protocol.
-Commands with ":x" mean that the x should be replaced with a number, the range
-of which is mentioned in the description.
-
 ## Commands
 
-### Support by Model
+### Support Matrix
 
 | Command                   | Ambi | Diamo | Domi | Edge | Ferri | Hush | Lush | Max | Nora | Osci | Quake |
 | ------------------------- | :--: | :---: | :--: | :--: | :---: | :--: | :--: | :-: | :--: | :--: | :---: |

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -120,35 +120,35 @@ Commands for Lovense toys follows these rules:
 
 ### Support Matrix
 
-| Command                   | Ambi | Diamo | Domi | Edge | Ferri | Hush | Lush | Max | Nora | Osci | Quake |
-| ------------------------- | :--: | :---: | :--: | :--: | :---: | :--: | :--: | :-: | :--: | :--: | :---: |
-| [`Air:In:𝛘`]              |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
-| [`Air:Level:𝛘`]           |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
-| [`Air:Out:𝛘`]             |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
-| [`ALight:𝛘`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`AutoSwith:𝛘:𝛄`]         |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Battery`]               |  ✔️  |   ❔   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
-| [`DeviceType`]            |  ✔️  |   ❔   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
-| [`GetALight`]             |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetAS`]                 |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetBatch`]              |  ✔️  |   ❔   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
-| [`GetLevel`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetLight`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetPatten:𝛘`]           |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`GetPatten`]             |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Light:𝛘`]               |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`PowerOff`]              |  ✔️  |   ❔   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |   ❔   |
-| [`Preset:𝛘`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Rotate:𝛘`]              |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
-| [`RotateAntiClockwise:𝛘`] |  ❌   |   ❌   |  ❌   |  ❌   |   ❌   |  ❌   |  ✔️  |  ❌  |  ❌   |      |       |
-| [`RotateChange`]          |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
-| [`RotateClockwise:𝛘`]     |  ❌   |   ❌   |  ❌   |  ❌   |   ❌   |  ❌   |  ✔️  |  ❌  |  ❌   |      |       |
-| [`SetLevel`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`StartMove:𝛘`]           |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
-| [`Status:𝛘`]              |  ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❌   |
-| [`StopMove:𝛘`]            |  ❌   |   ❔   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
-| [`Vibrate:𝛘`]             | All  |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
-| [`Vibrate𝛘:𝛄`]            |  ❔   |   ❔   |  ❔   |  ✔️  |   ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |  ✔️   |
+| Command                   | [Ambi] | [Diamo] | [Domi] | [Edge] | [Ferri] | [Hush] | [Lush] | [Max] | [Nora] | [Osci] | [Quake] |
+| :------------------------ | :----: | :-----: | :----: | :----: | :-----: | :----: | :----: | :---: | :----: | :----: | :-----: |
+| [`Air:In:𝛘`]              |   ❌    |    ❔    |   ❌    |   ❌    |    ❔    |   ❌    |   ❌    |  ✔️   |   ❌    |   ❌    |    ❌    |
+| [`Air:Level:𝛘`]           |   ❌    |    ❔    |   ❌    |   ❌    |    ❔    |   ❌    |   ❌    |  ✔️   |   ❌    |   ❌    |    ❌    |
+| [`Air:Out:𝛘`]             |   ❌    |    ❔    |   ❌    |   ❌    |    ❔    |   ❌    |   ❌    |  ✔️   |   ❌    |   ❌    |    ❌    |
+| [`ALight:𝛘`]              |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`AutoSwith:𝛘:𝛄`]         |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`Battery`]               |   ✔️   |    ❔    |   ✔️   |   ✔️   |    ❔    |   ✔️   |   ✔️   |  ✔️   |   ✔️   |   ✔️   |   ✔️    |
+| [`DeviceType`]            |   ✔️   |    ❔    |   ✔️   |   ✔️   |    ❔    |   ✔️   |   ✔️   |  ✔️   |   ✔️   |   ✔️   |   ✔️    |
+| [`GetALight`]             |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`GetAS`]                 |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`GetBatch`]              |   ✔️   |    ❔    |   ✔️   |   ✔️   |    ❔    |   ✔️   |   ✔️   |  ✔️   |   ✔️   |   ✔️   |   ✔️    |
+| [`GetLevel`]              |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`GetLight`]              |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`GetPatten:𝛘`]           |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`GetPatten`]             |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`Light:𝛘`]               |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`PowerOff`]              |   ✔️   |    ❔    |   ✔️   |   ✔️   |    ❔    |   ✔️   |   ✔️   |  ✔️   |   ✔️   |   ✔️   |    ❔    |
+| [`Preset:𝛘`]              |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`Rotate:𝛘`]              |   ❌    |    ❔    |   ❌    |   ❌    |    ❔    |   ❌    |   ❌    |   ❌   |   ✔️   |   ❌    |    ❌    |
+| [`RotateAntiClockwise:𝛘`] |   ❌    |    ❌    |   ❌    |   ❌    |    ❌    |   ❌    |   ✔️   |   ❌   |   ❌    |        |         |
+| [`RotateChange`]          |   ❌    |    ❔    |   ❌    |   ❌    |    ❔    |   ❌    |   ❌    |   ❌   |   ✔️   |   ❌    |    ❌    |
+| [`RotateClockwise:𝛘`]     |   ❌    |    ❌    |   ❌    |   ❌    |    ❌    |   ❌    |   ✔️   |   ❌   |   ❌    |        |         |
+| [`SetLevel`]              |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`StartMove:𝛘`]           |   ❌    |    ❔    |   ❌    |   ❌    |    ❔    |   ❌    |   ❌    |  ✔️   |   ✔️   |   ❌    |    ❌    |
+| [`Status:𝛘`]              |   ❔    |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❌    |
+| [`StopMove:𝛘`]            |   ❌    |    ❔    |   ❌    |   ❌    |    ❔    |   ❌    |   ❌    |  ✔️   |   ✔️   |   ❌    |    ❌    |
+| [`Vibrate:𝛘`]             |  All   |    ❔    |   ❔    |   ❔    |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |    ❔    |
+| [`Vibrate𝛘:𝛄`]            |   ❔    |    ❔    |   ❔    |   ✔️   |    ❔    |   ❔    |   ❔    |   ❔   |   ❔    |   ❔    |   ✔️    |
 
 [`Air:In:𝛘`]: #AirIn𝛘
 [`Air:Level:𝛘`]: #AirLevel𝛘
@@ -177,6 +177,17 @@ Commands for Lovense toys follows these rules:
 [`StopMove:𝛘`]: #StopMove:𝛘
 [`Vibrate:𝛘`]: #Vibrate:𝛘
 [`Vibrate𝛘:𝛄`]: #Vibrate:𝛘:𝛄
+[Ambi]: https://www.lovense.com/mini-bullet-vibrator-for-clitoral-simulation
+[Diamo]: https://www.lovense.com/bluetooth-vibrating-cock-ring
+[Domi]: https://www.lovense.com/super-powerful-wand-massager
+[Edge]: https://www.lovense.com/adjustable-prostate-massager
+[Ferri]: https://www.lovense.com/magnetic-panty-vibrator
+[Hush]: https://www.lovense.com/vibrating-butt-plug
+[Lush]: https://www.lovense.com/bluetooth-remote-control-vibrator
+[Max]: https://www.lovense.com/male-masturbators
+[Nora]: https://www.lovense.com/rabbit-vibrator
+[Osci]: https://www.lovense.com/oscillating-gspot-vibrator
+[Quake]: https://www.lovense.com/adjustable-dual-clit-gspot-vibrator
 
 ### `Air:In:𝛘`
 
@@ -191,6 +202,34 @@ Commands for Lovense toys follows these rules:
 ### `Battery`
 
 ### `DeviceType`
+
+Returns the toy's model identifier, firmware version, and Bluetooth MAC address,
+as a colon-delimited list.
+
+| Model | Identifier |
+| :---- | :--------: |
+| Ambi  |    `L`     |
+| Diamo |     ❔      |
+| Domi  |    `W`     |
+| Edge  |    `P`     |
+| Ferri |     ❔      |
+| Hush  |    `Z`     |
+| Lush  |    `S`     |
+| Max   |    `B`     |
+| Nora  | `A` or `C` |
+| Osci  |    `O`     |
+| Quake |    `J`     |
+
+#### Example
+
+```
+DeviceType;
+
+  C:11:0082059AD3BD;
+```
+
+Denotes a "Nora" toy model, running firmware version 1.1, with a Bluetooth
+address of `00:82:05:9A:D3:BD`.
 
 ### `GetALight`
 
@@ -231,42 +270,6 @@ Commands for Lovense toys follows these rules:
 ### `Vibrate:𝛘`
 
 ### `Vibrate𝛘:𝛄`
-
-#### Get Device Information
-
-Returns toy model type, firmware version, and Bluetooth MAC address, as a colon
-delimited list
-
-_Availability:_ All toys
-
-_Command Format_
-
-```
-DeviceType;
-```
-
-_Return Example_
-
-```
-C:11:0082059AD3BD;
-```
-
-Denotes Nora toy, running v1.1 firmware, with a Bluetooth address of
-00:82:05:9A:D3:BD
-
-**Model Types:**
-
-| Model | Type Letter |
-| ----- | ----------- |
-| Nora  | A or C      |
-| Max   | B           |
-| Ambi  | L           |
-| Lush  | S           |
-| Hush  | Z           |
-| Domi  | W           |
-| Edge  | P           |
-| Osci  | O           |
-| Quake | J           |
 
 #### Get Battery Level
 

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -13,7 +13,8 @@ hardware and firmware revisions for each model line.
 Lovense toys use a serial-style RPC protocol over Bluetooth, with command
 messages sent from the client and response messages sent from the toy. Messages
 are terminated by `;` semicolons. Valid commands will always receive at least
-one response, unless that command itself shuts down the toy first.
+one response, unless that command itself shuts down the toy first. Arguments and
+responses are often delimited by `:` colons.
 
 Depending on the model and firmware versions, valid commands that do not have
 meaningful return value will respond with either the string `OK` or the original
@@ -92,69 +93,75 @@ to identify the model in the toy's Bluetooth name and `DeviceType` response.
 | Model   | Identifier | Notes                    |
 | :------ | :--------: | :----------------------- |
 | Ambi    |    `L`     |                          |
-| Diamo   |     ❔      |                          |
+| Diamo   |     ❓      |                          |
 | Dolce   |    `J`     | previously named "Quake" |
 | Domi    |    `W`     |                          |
 | Edge    |    `P`     |                          |
-| Ferri   |     ❔      |                          |
+| Ferri   |     ❓      |                          |
 | Hush    |    `Z`     |                          |
 | Lush    |    `S`     |                          |
 | Max     |    `B`     |                          |
-| Mission |     ❔      | no longer in production  |
+| Mission |     ❓      | no longer in production  |
 | Nora    |    `A`     | newer Nora toys use `A`  |
 | Nora    |    `C`     | older Nora toys use `C`  |
 | Osci    |    `O`     |                          |
 
 ## Commands
 
+Note that there are many inconsistencies of formatting, spelling, and
+capitalization between the commands and responses. Be sure to copy the values
+exactly as the protocol expects.
+
 ### Compatibility Matrix
 
 | Command                   | Ambi | Diamo | Dolce | Domi | Edge | Ferri | Hush | Lush | Max | Mission | Nora | Osci |
 | :------------------------ | :--: | :---: | :---: | :--: | :--: | :---: | :--: | :--: | :-: | :-----: | :--: | :--: |
-| [`Air:In:𝛘`]              |  ❌   |   ❌   |   ❌   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |    ❔    |  ❌   |  ❌   |
-| [`Air:Level:𝛘`]           |  ❌   |   ❌   |   ❌   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |    ❔    |  ❌   |  ❌   |
-| [`Air:Out:𝛘`]             |  ❌   |   ❌   |   ❌   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |    ❔    |  ❌   |  ❌   |
+| [`Battery`]               |  ✔️  |  ✔️   |  ✔️   |  ✔️  |  ✔️  |  ✔️   |  ✔️  |  ✔️  | ✔️  |   ✔️    |  ✔️  |  ✔️  |
+| [`DeviceType`]            |  ✔️  |  ✔️   |  ✔️   |  ✔️  |  ✔️  |  ✔️   |  ✔️  |  ✔️  | ✔️  |   ✔️    |  ✔️  |  ✔️  |
+| [`GetBatch`]              |  ✔️  |  ✔️   |  ✔️   |  ✔️  |  ✔️  |  ✔️   |  ✔️  |  ✔️  | ✔️  |   ✔️    |  ✔️  |  ✔️  |
+| [`PowerOff`]              |  ✔️  |  ✔️   |  ✔️   |  ✔️  |  ✔️  |  ✔️   |  ✔️  |  ✔️  | ✔️  |   ✔️    |  ✔️  |  ✔️  |
+| [`Vibrate:𝛘`]             |  ✔️  |  ✔️   |  ✔️   |  ✔️  |  ✔️  |  ✔️   |  ✔️  |  ✔️  | ✔️  |   ✔️    |  ✔️  |  ✔️  |
+|                           |      |       |       |      |      |       |      |      |     |         |      |      |
+| [`Air:In:𝛘`]              |  ❌   |   ❌   |   ❌   |  ❌   |  ❌   |   ❌   |  ❌   |  ❌   | ✔️  |    ❌    |  ❌   |  ❌   |
+| [`Air:Level:𝛘`]           |  ❌   |   ❌   |   ❌   |  ❌   |  ❌   |   ❌   |  ❌   |  ❌   | ✔️  |    ❌    |  ❌   |  ❌   |
+| [`Air:Out:𝛘`]             |  ❌   |   ❌   |   ❌   |  ❌   |  ❌   |   ❌   |  ❌   |  ❌   | ✔️  |    ❌    |  ❌   |  ❌   |
 | [`ALight:𝛘`]              |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
 | [`AutoSwith:𝛘:𝛄`]         |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
-| [`Battery`]               |  ✔️  |   ❔   |  ✔️   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |    ❔    |  ✔️  |  ✔️  |
-| [`DeviceType`]            |  ✔️  |   ❔   |  ✔️   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |    ❔    |  ✔️  |  ✔️  |
-| [`GetALight`]             |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
+| [`GetAlight`]             |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
 | [`GetAS`]                 |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
-| [`GetBatch`]              |  ✔️  |   ❔   |  ✔️   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |    ❔    |  ✔️  |  ✔️  |
 | [`GetLevel`]              |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
 | [`GetLight`]              |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
 | [`GetPatten:𝛘`]           |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
 | [`GetPatten`]             |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
 | [`Light:𝛘`]               |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
-| [`PowerOff`]              |  ✔️  |   ❔   |   ❔   |  ✔️  |  ✔️  |   ❔   |  ✔️  |  ✔️  | ✔️  |    ❔    |  ✔️  |  ✔️  |
 | [`Preset:𝛘`]              |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
-| [`Rotate:𝛘`]              |  ❌   |   ❔   |   ❌   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   |  ❌  |    ❔    |  ✔️  |  ❌   |
-| [`RotateAntiClockwise:𝛘`] |  ❌   |       |       |  ❌   |  ❌   |   ❌   |  ❌   |  ❌   | ✔️  |    ❔    |  ❌   |  ❌   |
-| [`RotateChange`]          |  ❌   |   ❔   |   ❌   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   |  ❌  |    ❔    |  ✔️  |  ❌   |
-| [`RotateClockwise:𝛘`]     |  ❌   |       |       |  ❌   |  ❌   |   ❌   |  ❌   |  ❌   | ✔️  |    ❔    |  ❌   |  ❌   |
+| [`Rotate:𝛘`]              |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
+| [`RotateAntiClockwise:𝛘`] |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
+| [`RotateChange`]          |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
+| [`RotateClockwise:𝛘`]     |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
 | [`SetLevel`]              |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
-| [`StartMove:𝛘`]           |  ❌   |   ❔   |   ❌   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |    ❔    |  ✔️  |  ❌   |
-| [`Status:𝛘`]              |  ❔   |   ❔   |   ❌   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
-| [`StopMove:𝛘`]            |  ❌   |   ❔   |   ❌   |  ❌   |  ❌   |   ❔   |  ❌   |  ❌   | ✔️  |    ❔    |  ✔️  |  ❌   |
-| [`Vibrate:𝛘`]             | All  |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
-| [`Vibrate𝛘:𝛄`]            |  ❔   |   ❔   |  ✔️   |  ❔   |  ✔️  |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
+| [`StartMove:𝛘`]           |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
+| [`Status:𝛘`]              |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
+| [`StopMove:𝛘`]            |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
+| [`Vibrate𝛘:𝛄`]            |  ❔   |   ❔   |   ❔   |  ❔   |  ❔   |   ❔   |  ❔   |  ❔   |  ❔  |    ❔    |  ❔   |  ❔   |
 
+[`Battery`]: #Battery
+[`DeviceType`]: #DeviceType
+[`GetBatch`]: #GetBatch
+[`PowerOff`]: #PowerOff
+[`Vibrate:𝛘`]: #Vibrate:𝛘
 [`Air:In:𝛘`]: #AirIn𝛘
 [`Air:Level:𝛘`]: #AirLevel𝛘
 [`Air:Out:𝛘`]: #AirOut𝛘
 [`ALight:𝛘`]: #ALight𝛘
 [`AutoSwith:𝛘:𝛄`]: #AutoSwith𝛘𝛄
-[`Battery`]: #Battery
-[`DeviceType`]: #DeviceType
-[`GetALight`]: #GetALight
+[`GetAlight`]: #GetAlight
 [`GetAS`]: #GetAS
-[`GetBatch`]: #GetBatch
 [`GetLevel`]: #GetLevel
 [`GetLight`]: #GetLight
 [`GetPatten:𝛘`]: #GetPatten𝛘
 [`GetPatten`]: #GetPatten
 [`Light:𝛘`]: #Light𝛘
-[`PowerOff`]: #PowerOff
 [`Preset:𝛘`]: #Preset𝛘
 [`Rotate:𝛘`]: #Rotate𝛘
 [`RotateAntiClockwise:𝛘`]: #RotateAntiClockwise𝛘
@@ -164,25 +171,13 @@ to identify the model in the toy's Bluetooth name and `DeviceType` response.
 [`StartMove:𝛘`]: #StartMove:𝛘
 [`Status:𝛘`]: #Status:𝛘
 [`StopMove:𝛘`]: #StopMove:𝛘
-[`Vibrate:𝛘`]: #Vibrate:𝛘
 [`Vibrate𝛘:𝛄`]: #Vibrate:𝛘:𝛄
-
-### `Air:In:𝛘`
-
-### `Air:Level:𝛘`
-
-### `Air:Out:𝛘`
-
-### `ALight:𝛘`
-
-### `AutoSwith:𝛘:𝛄`
 
 ### `Battery`
 
-Returns the battery level of the toy as an integer percentage from 0-100.
-
-Some toys will also prepend an `s` character (such as `s99`) to indicate when
-they are active (i.e. when a vibrator motor is turned on).
+Returns the battery level of the toy as an integer percentage from 0-100. Some
+toys will also prepend an `s` character (such as `s99`) to indicate when they
+are active (i.e. when a vibrator motor is turned on).
 
 #### Example
 
@@ -210,11 +205,70 @@ DeviceType;
 Denotes a "Nora" toy model, running firmware version 1.1, with a Bluetooth
 address of `00:82:05:9A:D3:BD`.
 
-### `GetALight`
+### `GetBatch`
+
+Returns the production batch number for this toy. The digits correspond to
+correspond to some `YYMMDD` date during production.
+
+#### Example
+
+```
+GetBatch;
+
+  190124;
+```
+
+### `PowerOff`
+
+Immediately powers off the toy. It disconnects before sending any result
+message.
+
+#### Example
+
+```
+PowerOff;
+```
+
+### `Vibrate:𝛘`
+
+### `Air:In:𝛘`
+
+### `Air:Level:𝛘`
+
+### `Air:Out:𝛘`
+
+### `ALight:𝛘`
+
+Enables (`On`) or disables (`Off`) the cosmetic ring of white LEDs on a Domi
+toy. This corresponds to the setting labelled "Enable/Disable Lights" in the
+Lovense Remote app. See also [`GetAlight`].
+
+#### Example
+
+```
+ALight:Off;
+
+  OK;
+```
+
+### `AutoSwith:𝛘:𝛄`
+
+### `GetAlight`
+
+Determine whether the cosmetic ring of white LEDs on a Domi toy are enabled
+(`1`) or disabled (`0`). This corresponds to the setting labelled
+"Enable/Disable Lights" in the Lovense Remote app. See also [`ALight:𝛘`].
+
+#### Example
+
+```
+GetAlight;
+
+
+  Alight:1;
+```
 
 ### `GetAS`
-
-### `GetBatch`
 
 ### `GetLevel`
 
@@ -225,8 +279,6 @@ address of `00:82:05:9A:D3:BD`.
 ### `GetPatten`
 
 ### `Light:𝛘`
-
-### `PowerOff`
 
 ### `Preset:𝛘`
 
@@ -246,27 +298,7 @@ address of `00:82:05:9A:D3:BD`.
 
 ### `StopMove:𝛘`
 
-### `Vibrate:𝛘`
-
 ### `Vibrate𝛘:𝛄`
-
-#### Turn Off Power
-
-Turns off power to the toy.
-
-_Availability:_ All toys
-
-_Command Format_
-
-```
-PowerOff;
-```
-
-_Return Example_
-
-```
-OK;
-```
 
 #### Device Status
 
@@ -672,25 +704,6 @@ _Return Example_
 OK;
 ```
 
-#### Get Production Batch Number
-
-Returns the production batch number for this toy. This digits appear to
-correspond to a `YYMMDD` date during manufacture.
-
-_Availability:_ All toys? Confirmed: Lush 2, Hush, Domi, Dolce.
-
-_Command Format_
-
-```
-GetBatch;
-```
-
-_Return Example_
-
-```
-190124;
-```
-
 #### Count Programmed Patterns
 
 List the indexes of the patterns that are currently programmed into the toy. The
@@ -759,7 +772,7 @@ _Return Example_
 P4:01/01:346797643;
 ```
 
-#### Run Programmed Patern
+#### Run Programmed Pattern
 
 Starts running a programmed pattern on a loop. Takes an positive integer pattern
 index to start running it, or 0 to stop running the pattern.

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -1,8 +1,73 @@
 # Lovense
 
-## Introduction
+## Background
 
-Lovense has been manufacturing toys since 2011.
+Lovense has been manufacturing toys since 2011. Many of their toy models have
+undergone multiple hardware and firmware revisions since. The protocol changes
+between versions are usually minor, but for clarity: unless otherwise indicated,
+this document refers to the latest of hardware and firmware for a given model.
+
+## Supported Commands by Model
+
+| Command                   | Ambi | Domi | Edge | Hush | Lush | Max | Nora | Osci | Quake |
+| ------------------------- | :--: | :--: | :--: | :--: | :--: | :-: | :--: | :--: | :---: |
+| [`Air:In:𝛘`]              |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
+| [`Air:Level:𝛘`]           |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
+| [`Air:Out:𝛘`]             |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ❌   |  ❌   |   ❌   |
+| [`ALight:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`AutoSwith:𝛘:𝛄`]         |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Battery`]               |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
+| [`DeviceType`]            |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
+| [`GetALight`]             |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetAS`]                 |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetBatch`]              |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |  ✔️   |
+| [`GetLevel`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetLight`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetPatten:𝛘`]           |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`GetPatten`]             |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Light:𝛘`]               |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`PowerOff`]              |  ✔️  |  ✔️  |  ✔️  |  ✔️  |  ✔️  | ✔️  |  ✔️  |  ✔️  |   ❔   |
+| [`Preset:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Rotate:𝛘`]              |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
+| [`RotateAntiClockwise:𝛘`] |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
+| [`RotateChange`]          |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
+| [`RotateClockwise:𝛘`]     |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   |  ❌  |  ✔️  |  ❌   |   ❌   |
+| [`SetLevel`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`SetLevel`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`StartMove:𝛘`]           |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
+| [`Status:𝛘`]              |  ❔   |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❌   |
+| [`StopMove:𝛘`]            |  ❌   |  ❌   |  ❌   |  ❌   |  ❌   | ✔️  |  ✔️  |  ❌   |   ❌   |
+| [`Vibrate:𝛘`]             | All  |  ❔   |  ❔   |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |   ❔   |
+| [`Vibrate𝛘:𝛄`]            |  ❔   |  ❔   |  ✔️  |  ❔   |  ❔   |  ❔  |  ❔   |  ❔   |  ✔️   |
+
+[`Air:In:𝛘`]: #Air:In:𝛘
+[`Air:Level:𝛘`]: #Air:Level:𝛘
+[`Air:Out:𝛘`]: #Air:Out:𝛘
+[`ALight:𝛘`]: #ALight:𝛘
+[`AutoSwith:𝛘:𝛄`]: #AutoSwith:𝛘:𝛄
+[`Battery`]: #Battery
+[`DeviceType`]: #DeviceType
+[`GetALight`]: #GetALight
+[`GetAS`]: #GetAS
+[`GetBatch`]: #GetBatch
+[`GetLevel`]: #GetLevel
+[`GetLight`]: #GetLight
+[`GetPatten:𝛘`]: #GetPatten:𝛘
+[`GetPatten`]: #GetPatten
+[`Light:𝛘`]: #Light:𝛘
+[`PowerOff`]: #PowerOff
+[`Preset:𝛘`]: #Preset:𝛘
+[`Rotate:𝛘`]: #Rotate:𝛘
+[`RotateAntiClockwise:𝛘`]: #RotateAntiClockwise:𝛘
+[`RotateChange`]: #RotateChange
+[`RotateClockwise:𝛘`]: #RotateClockwise:𝛘
+[`SetLevel`]: #SetLevel
+[`SetLevel`]: #SetLevel
+[`StartMove:𝛘`]: #StartMove:𝛘
+[`Status:𝛘`]: #Status:𝛘
+[`StopMove:𝛘`]: #StopMove:𝛘
+[`Vibrate:𝛘`]: #Vibrate:𝛘
+[`Vibrate𝛘:𝛄`]: #Vibrate:𝛘:𝛄
 
 ## Bluetooth Details
 
@@ -643,11 +708,8 @@ Domi response using one-digit part indices:
 _Return Example_
 
 ```
-P4:1/5:000042003720;
-P4:2/5:000002436658;
-P4:3/5:997339993001;
-P4:4/5:291111115111;
-P4:5/5:1110000000;
+P4:1/5:000042003720; P4:2/5:000002436658; P4:3/5:997339993001;
+P4:4/5:291111115111; P4:5/5:1110000000;
 ```
 
 Lush 2 response using two-digit part indices:
@@ -701,3 +763,6 @@ hardware/firmware.
   [https://github.com/metafetish/lovesense-js](https://github.com/metafetish/lovesense-js)
 - WebBluetooth JS Library/Demo (Hush only):
   [https://github.com/metafetish/lovesense-hush-js-demo](https://github.com/metafetish/lovesense-hush-js-demo)
+
+```
+```

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -100,31 +100,32 @@ as a colon delimited list
 _Availability:_ All toys
 
 _Command Format_
+
 ```
 DeviceType;
 ```
 
 _Return Example_
+
 ```
 C:11:0082059AD3BD;
 ```
 
-Denotes Nora toy, running v1.1 firmware, BT Addr of 00:82:05:9A:D3:BD
+Denotes Nora toy, running v1.1 firmware, with a Bluetooth address of 00:82:05:9A:D3:BD
 
 **Model Types:**
 
 | Model | Type Letter |
 | ----- | ----------- |
-| Nora | A or C |
-| Max | B |
-| Ambi | L |
-| Lush | S |
-| Hush | Z |
-| Domi | W |
-| Edge | P |
-| Osci | O |
-| Quake | J |
-
+| Nora  | A or C      |
+| Max   | B           |
+| Ambi  | L           |
+| Lush  | S           |
+| Hush  | Z           |
+| Domi  | W           |
+| Edge  | P           |
+| Osci  | O           |
+| Quake | J           |
 
 #### Get Battery Level
 
@@ -133,11 +134,13 @@ Returns the battery level of the toy as an integer percentage from 0-100.
 _Availability:_ All toys
 
 _Command Format_
+
 ```
 Battery;
 ```
 
 _Return Example_
+
 ```
 85;
 ```
@@ -151,11 +154,13 @@ Turns off power to the toy.
 _Availability:_ All toys
 
 _Command Format_
+
 ```
 PowerOff;
 ```
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -167,11 +172,13 @@ Retreive the status of the toy.
 _Availability:_ All toys
 
 _Command Format_
+
 ```
 Status:1;
 ```
 
 _Return Example_
+
 ```
 2;
 ```
@@ -187,6 +194,7 @@ Changes the vibration speed for the toy. Takes integer values from 0-20.
 _Availability:_ All toys
 
 _Command Format_
+
 ```
 Vibrate:10;
 ```
@@ -194,6 +202,7 @@ Vibrate:10;
 Sets vibration speed to 10 (50%).
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -217,6 +226,7 @@ The read command returns 0 or 1; the write command accepts "Off" and "On".
 _Availability:_ All toys? Confirmed: Domi, Hush, Lush 2
 
 _Command Format_
+
 ```
 GetAS;
 ```
@@ -224,6 +234,7 @@ GetAS;
 Read "AutoSwith" options.
 
 _Return Example_
+
 ```
 AutoSwith:0:1;
 ```
@@ -232,6 +243,7 @@ Indicates "turn off on disconnect" disabled;
 "last level on reconnect" enabled.
 
 _Command Format_
+
 ```
 AutoSwith:On:Off;
 ```
@@ -239,6 +251,7 @@ AutoSwith:On:Off;
 Set AutoSwith features to On and Off, respectively.
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -255,6 +268,7 @@ The read command returns 0 or 1; the write command accepts "off" and "on".
 _Availability:_ All toys? Confirmed: Domi, Hush, Lush 2
 
 _Command Format_
+
 ```
 GetLight;
 ```
@@ -262,6 +276,7 @@ GetLight;
 Read Light setting.
 
 _Return Example_
+
 ```
 Light:1;
 ```
@@ -269,6 +284,7 @@ Light:1;
 LED enabled
 
 _Command Format_
+
 ```
 Light:off;
 ```
@@ -276,6 +292,7 @@ Light:off;
 Disable power/connection LED
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -291,6 +308,7 @@ Controls ring of white LEDs on Domi.
 The read command returns 0 or 1; the write command accepts "Off" and "On".
 
 _Command Format_
+
 ```
 GetAlight;
 ```
@@ -298,15 +316,17 @@ GetAlight;
 Read ALight setting.
 
 _Return Example_
+
 ```
 Alight:1;
 ```
 
 Lights enabled
 
-*Important:* note different capitalization between read and write commands
+_Important:_ note different capitalization between read and write commands
 
 _Command Format_
+
 ```
 ALight:Off;
 ```
@@ -314,6 +334,7 @@ ALight:Off;
 Disable lights or power LED
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -327,6 +348,7 @@ same integer values used for the Vibrate command.
 _Availability:_ Domi
 
 _Command Format_
+
 ```
 GetLevel;
 ```
@@ -334,6 +356,7 @@ GetLevel;
 Fetch configured levels.
 
 _Return Example_
+
 ```
 1,9,20;
 ```
@@ -342,6 +365,7 @@ Vibration levels. Indicates 1 for low, 9 for medium, 20 for high.
 This is the factory default.
 
 _Command Format_
+
 ```
 SetLevel:3:16;
 ```
@@ -350,10 +374,10 @@ Set High to level 16. 1, 2, and 3 as the first argument refer to
 low, medium, and high, respectively.
 
 _Return Example_
+
 ```
 OK;
 ```
-
 
 #### Start Accelerometer Data Stream
 
@@ -364,11 +388,13 @@ followed by 3 16-bit little-endian numbers.
 _Availability:_ Max, Nora
 
 _Command Format_
+
 ```
 StartMove:1;
 ```
 
 _Return Example_
+
 ```
 GEF008312ED00;
 ```
@@ -382,11 +408,13 @@ Stops stream of accelerometer data.
 _Availability:_ Max, Nora
 
 _Command Format_
+
 ```
 StopMove:1;
 ```
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -398,11 +426,13 @@ Changes the direction of rotation for the toy.
 _Availability:_ Nora
 
 _Command Format_
+
 ```
 RotateChange;
 ```
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -414,6 +444,7 @@ Changes the rotation speed of the Nora toy. Takes integer values from 0-20.
 _Availability_: Nora
 
 _Command Format_
+
 ```
 Rotate:10;
 ```
@@ -421,6 +452,7 @@ Rotate:10;
 Sets rotation speed to 10 (50%).
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -432,6 +464,7 @@ Changes the inflation level of the Max toy. Takes integer values from 0-5.
 _Availability:_ Max
 
 _Command Format_
+
 ```
 Air:Level:3;
 ```
@@ -439,6 +472,7 @@ Air:Level:3;
 Sets air level to 3 (60%).
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -451,6 +485,7 @@ is 3, and "Air:In:1;" is sent, will inflate to 4.
 _Availability:_ Max
 
 _Command Format_
+
 ```
 Air:In:1;
 ```
@@ -458,6 +493,7 @@ Air:In:1;
 Sets air level to 1 level more inflated than it was.
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -470,6 +506,7 @@ is 3, and "Air:Out:1;" is sent, will deflate to 2.
 _Availability:_ Max
 
 _Command Format_
+
 ```
 Air:Out:1;
 ```
@@ -477,6 +514,7 @@ Air:Out:1;
 Sets air level to 1 level deflated than it was.
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -489,11 +527,13 @@ This digits appear to correspond to a `YYMMDD` date during manufacture.
 _Availability:_ All toys? Confirmed: Lush 2, Hush, Domi, Quake.
 
 _Command Format_
+
 ```
 GetBatch;
 ```
 
 _Return Example_
+
 ```
 190124;
 ```
@@ -507,11 +547,13 @@ always be a single digit.
 _Availability:_ Lush 2, Domi
 
 _Command Format_
+
 ```
 GetPatten;
 ```
 
 _Return Example_
+
 ```
 P:01234;
 ```
@@ -542,6 +584,7 @@ two digits.
 _Availability:_ Lush 2, Domi
 
 _Command Format_
+
 ```
 GetPatten:4;
 ```
@@ -549,6 +592,7 @@ GetPatten:4;
 Domi response using one-digit part indices:
 
 _Return Example_
+
 ```
 P4:1/5:000042003720;
 P4:2/5:000002436658;
@@ -560,6 +604,7 @@ P4:5/5:1110000000;
 Lush 2 response using two-digit part indices:
 
 _Return Example_
+
 ```
 P4:01/01:346797643;
 ```
@@ -575,11 +620,13 @@ to be able to take indices from 0 to 4. Other toys have not been tested.
 _Availability:_ Lush, Hush, Ambi, Domi, Edge, Osci
 
 _Command Format_
+
 ```
 Preset:8;
 ```
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -590,10 +637,10 @@ The applications and repositories below contain implementations of the
 Lovense communications protocol, or have relevant information about
 the hardware/firmware.
 
-* Buttplug C# (All toys): [https://github.com/metafetish/buttplug-csharp](https://github.com/metafetish/buttplug-csharp)
-* Buttplug JS (All toys): [https://github.com/metafetish/buttplug-js](https://github.com/metafetish/buttplug-js)
-* lovesense-rs (Rust, Max/Nora only): [https://github.com/metafetish/lovesense-rs](https://github.com/metafetish/lovesense-rs)
-* lovesense-py (Python, Max/Nora only): [https://github.com/metafetish/lovesense-py](https://github.com/metafetish/lovesense-py)
-* Max/MSP patch (Max/MSP, Max/Nora only): [https://github.com/metafetish/lovesense-max](https://github.com/metafetish/lovesense-max)
-* Node.js Library (Max/Nora only): [https://github.com/metafetish/lovesense-js](https://github.com/metafetish/lovesense-js)
-* WebBluetooth JS Library/Demo (Hush only): [https://github.com/metafetish/lovesense-hush-js-demo](https://github.com/metafetish/lovesense-hush-js-demo)
+- Buttplug C# (All toys): [https://github.com/metafetish/buttplug-csharp](https://github.com/metafetish/buttplug-csharp)
+- Buttplug JS (All toys): [https://github.com/metafetish/buttplug-js](https://github.com/metafetish/buttplug-js)
+- lovesense-rs (Rust, Max/Nora only): [https://github.com/metafetish/lovesense-rs](https://github.com/metafetish/lovesense-rs)
+- lovesense-py (Python, Max/Nora only): [https://github.com/metafetish/lovesense-py](https://github.com/metafetish/lovesense-py)
+- Max/MSP patch (Max/MSP, Max/Nora only): [https://github.com/metafetish/lovesense-max](https://github.com/metafetish/lovesense-max)
+- Node.js Library (Max/Nora only): [https://github.com/metafetish/lovesense-js](https://github.com/metafetish/lovesense-js)
+- WebBluetooth JS Library/Demo (Hush only): [https://github.com/metafetish/lovesense-hush-js-demo](https://github.com/metafetish/lovesense-hush-js-demo)

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -21,7 +21,7 @@ These toys include:
 - Nora
 
 When paired with a system via Bluetooth 2.0, these toys identify as a
-serial port. These toys are also capable of using Bluetooth 4.0, as
+serial port. These toys are also capable of using Bluetooth LE, as
 outlined in the next section.
 
 ### Bluetooth LE Toys

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -6,43 +6,42 @@ Lovense has been manufacturing toys since 2011.
 
 ## Bluetooth Details
 
-While all Lovense toys use the same protocol, they can communicate
-over Bluetooth differently, depending on when they were released.
+While all Lovense toys use the same protocol, they can communicate over
+Bluetooth differently, depending on when they were released.
 
 ### Bluetooth 2.0 Toys
 
-The first toys released by Lovense used both Bluetooth 2.0 SPP
-(emulating a serial port) and Bluetooth LE. This was most likely due
-to the sparse mobile support of BTLE when they were released.
+The first toys released by Lovense used both Bluetooth 2.0 SPP (emulating a
+serial port) and Bluetooth LE. This was most likely due to the sparse mobile
+support of BTLE when they were released.
 
 These toys include:
 
 - Max
 - Nora
 
-When paired with a system via Bluetooth 2.0, these toys identify as a
-serial port. These toys are also capable of using Bluetooth LE, as
-outlined in the next section.
+When paired with a system via Bluetooth 2.0, these toys identify as a serial
+port. These toys are also capable of using Bluetooth LE, as outlined in the next
+section.
 
 ### Bluetooth LE Toys
 
-Starting with the Lush, all toys released by Lovense use only
-Bluetooth LE.
+Starting with the Lush, all toys released by Lovense use only Bluetooth LE.
 
-These toys have GATT characteristics to mimic the RX/TX setup of the
-serial port style control of the old toys. The GATT service and
-characteristic IDs differ between different toy firmware versions.
+These toys have GATT characteristics to mimic the RX/TX setup of the serial port
+style control of the old toys. The GATT service and characteristic IDs differ
+between different toy firmware versions.
 
-It's difficult to keep a current list of exact Lovense device names
-and service/characteristic UUIDs, as they tend to change rapidly on
-firmware updates. The following rules can be used for finding and
-connecting to Lovense toys.
+It's difficult to keep a current list of exact Lovense device names and
+service/characteristic UUIDs, as they tend to change rapidly on firmware
+updates. The following rules can be used for finding and connecting to Lovense
+toys.
 
-Lovense toy names always start with "LVS-". What comes after that
-varies depending on when the toy was released. Early toys used names
-involving the single character identifier, like "LVS-A011", while
-newer toys use the full product name, like "LVS-Edge36". The last 2
-numbers denote the firmware version the toy is running.
+Lovense toy names always start with "LVS-". What comes after that varies
+depending on when the toy was released. Early toys used names involving the
+single character identifier, like "LVS-A011", while newer toys use the full
+product name, like "LVS-Edge36". The last 2 numbers denote the firmware version
+the toy is running.
 
 Lovense toys usually have one of 3 service ID formats:
 
@@ -52,59 +51,59 @@ Lovense toys usually have one of 3 service ID formats:
 XY300001-002Z-4bd4-bbd5-a6920e4c5653
 ```
 
-The first two service IDs are static, and represent the service IDs
-used by first and second generation Lovense toys. The 3rd service ID
-can vary, with
+The first two service IDs are static, and represent the service IDs used by
+first and second generation Lovense toys. The 3rd service ID can vary, with
 
 - X usually being 0x4 or 0x5
 - Y being any number 0x0-0xf
 - Z usually being 0x3 or 0x4
 
-While some Bluetooth APIs can wildcard services, others like
-WebBluetooth require an exact service UUID to connect. For these
-instances, it's recommended to just generate out all 32 variations of
-the last service, for a total of 34 services, to use with the
-optionalServices portion of a WebBluetooth connection filter.
+While some Bluetooth APIs can wildcard services, others like WebBluetooth
+require an exact service UUID to connect. For these instances, it's recommended
+to just generate out all 32 variations of the last service, for a total of 34
+services, to use with the optionalServices portion of a WebBluetooth connection
+filter.
 
-To identify the type of toy after connecting, it is recommended to use
-the [DeviceType;](lovense.md#get-device-information) message, outlined
-below. This will return a device model identifier.
+To identify the type of toy after connecting, it is recommended to use the
+[DeviceType;](lovense.md#get-device-information) message, outlined below. This
+will return a device model identifier.
 
 ## Protocol
 
 Commands for Lovense toys follows these rules:
 
 - Commands and replies are strings, using semicolons to mark their end.
-- All commands start with a command identifier word, then possibly
-  either specifiers or levels, delimited by colons. e.g. "Vibrate:5;"
-  would set vibration to 5.
-- Replies are in the context of the command (i.e. sending "Battery;"
-  will just return a number, like "85;"), but can still be colon
-  delimited lists.
-- Commands that do not return a context specific value will return
-  "OK;" on success, "ERR;" on error.
+- All commands start with a command identifier word, then possibly either
+  specifiers or levels, delimited by colons. e.g. "Vibrate:5;" would set
+  vibration to 5.
+- Replies are in the context of the command (i.e. sending "Battery;" will just
+  return a number, like "85;"), but can still be colon delimited lists.
+- Commands that do not return a context specific value will return "OK;" on
+  success, "ERR;" on error.
 
 ### Command List
 
-The following is the known command table for all toys. Anything send or
-received over the serial port is in quotes to denote communication, but
-should not be sent using quotes if you are implementing your own version
-of this protocol. Commands with ":x" mean that the x should be replaced
-with a number, the range of which is mentioned in the description.
+The following is the known command table for all toys. Anything send or received
+over the serial port is in quotes to denote communication, but should not be
+sent using quotes if you are implementing your own version of this protocol.
+Commands with ":x" mean that the x should be replaced with a number, the range
+of which is mentioned in the description.
 
 #### Get Device Information
 
-Returns toy model type, firmware version, and Bluetooth MAC address,
-as a colon delimited list
+Returns toy model type, firmware version, and Bluetooth MAC address, as a colon
+delimited list
 
 _Availability:_ All toys
 
 _Command Format_
+
 ```
 DeviceType;
 ```
 
 _Return Example_
+
 ```
 C:11:0082059AD3BD;
 ```
@@ -115,15 +114,14 @@ Denotes Nora toy, running v1.1 firmware, BT Addr of 00:82:05:9A:D3:BD
 
 | Model | Type Letter |
 | ----- | ----------- |
-| Nora | A or C |
-| Max | B |
-| Ambi | L |
-| Lush | S |
-| Hush | Z |
-| Domi | W |
-| Edge | P |
-| Osci | O |
-
+| Nora  | A or C      |
+| Max   | B           |
+| Ambi  | L           |
+| Lush  | S           |
+| Hush  | Z           |
+| Domi  | W           |
+| Edge  | P           |
+| Osci  | O           |
 
 #### Get Battery Level
 
@@ -132,11 +130,13 @@ Returns the battery level of the toy as an integer percentage from 0-100.
 _Availability:_ All toys
 
 _Command Format_
+
 ```
 Battery;
 ```
 
 _Return Example_
+
 ```
 85;
 ```
@@ -150,11 +150,13 @@ Turns off power to the toy.
 _Availability:_ All toys
 
 _Command Format_
+
 ```
 PowerOff;
 ```
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -166,11 +168,13 @@ Retreive the status of the toy.
 _Availability:_ All toys
 
 _Command Format_
+
 ```
 Status:1;
 ```
 
 _Return Example_
+
 ```
 2;
 ```
@@ -186,6 +190,7 @@ Changes the vibration speed for the toy. Takes integer values from 0-20.
 _Availability:_ All toys
 
 _Command Format_
+
 ```
 Vibrate:10;
 ```
@@ -193,14 +198,15 @@ Vibrate:10;
 Sets vibration speed to 10 (50%).
 
 _Return Example_
+
 ```
 OK;
 ```
 
 #### Configure Toy Settings
 
-There are settings configurable through the Lovense Remote
-application which have read and write commands.
+There are settings configurable through the Lovense Remote application which
+have read and write commands.
 
 ##### AutoSwith
 
@@ -216,6 +222,7 @@ The read command returns 0 or 1; the write command accepts "Off" and "On".
 _Availability:_ All toys? Confirmed: Domi, Hush, Lush 2
 
 _Command Format_
+
 ```
 GetAS;
 ```
@@ -223,14 +230,15 @@ GetAS;
 Read "AutoSwith" options.
 
 _Return Example_
+
 ```
 AutoSwith:0:1;
 ```
 
-Indicates "turn off on disconnect" disabled;
-"last level on reconnect" enabled.
+Indicates "turn off on disconnect" disabled; "last level on reconnect" enabled.
 
 _Command Format_
+
 ```
 AutoSwith:On:Off;
 ```
@@ -238,14 +246,15 @@ AutoSwith:On:Off;
 Set AutoSwith features to On and Off, respectively.
 
 _Return Example_
+
 ```
 OK;
 ```
 
 ##### Light
 
-Labelled "Enable/Disable LED" in Lovense Remote. Not shown
-in Lovense Remote for Domi.
+Labelled "Enable/Disable LED" in Lovense Remote. Not shown in Lovense Remote for
+Domi.
 
 Controls power/connection LED.
 
@@ -254,6 +263,7 @@ The read command returns 0 or 1; the write command accepts "off" and "on".
 _Availability:_ All toys? Confirmed: Domi, Hush, Lush 2
 
 _Command Format_
+
 ```
 GetLight;
 ```
@@ -261,6 +271,7 @@ GetLight;
 Read Light setting.
 
 _Return Example_
+
 ```
 Light:1;
 ```
@@ -268,6 +279,7 @@ Light:1;
 LED enabled
 
 _Command Format_
+
 ```
 Light:off;
 ```
@@ -275,6 +287,7 @@ Light:off;
 Disable power/connection LED
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -290,6 +303,7 @@ Controls ring of white LEDs on Domi.
 The read command returns 0 or 1; the write command accepts "Off" and "On".
 
 _Command Format_
+
 ```
 GetAlight;
 ```
@@ -297,15 +311,17 @@ GetAlight;
 Read ALight setting.
 
 _Return Example_
+
 ```
 Alight:1;
 ```
 
 Lights enabled
 
-*Important:* note different capitalization between read and write commands
+_Important:_ note different capitalization between read and write commands
 
 _Command Format_
+
 ```
 ALight:Off;
 ```
@@ -313,19 +329,21 @@ ALight:Off;
 Disable lights or power LED
 
 _Return Example_
+
 ```
 OK;
 ```
 
 #### Preset Levels
 
-The Domi allows customization of the low, medium, and high levels
-selectable using the hardware buttons. The raw levels are the
-same integer values used for the Vibrate command.
+The Domi allows customization of the low, medium, and high levels selectable
+using the hardware buttons. The raw levels are the same integer values used for
+the Vibrate command.
 
 _Availability:_ Domi
 
 _Command Format_
+
 ```
 GetLevel;
 ```
@@ -333,41 +351,45 @@ GetLevel;
 Fetch configured levels.
 
 _Return Example_
+
 ```
 1,9,20;
 ```
 
-Vibration levels. Indicates 1 for low, 9 for medium, 20 for high.
-This is the factory default.
+Vibration levels. Indicates 1 for low, 9 for medium, 20 for high. This is the
+factory default.
 
 _Command Format_
+
 ```
 SetLevel:3:16;
 ```
 
-Set High to level 16. 1, 2, and 3 as the first argument refer to
-low, medium, and high, respectively.
+Set High to level 16. 1, 2, and 3 as the first argument refer to low, medium,
+and high, respectively.
 
 _Return Example_
+
 ```
 OK;
 ```
 
-
 #### Start Accelerometer Data Stream
 
-Starts a stream of accelerometer data. Will send constantly until stop
-command is sent. Incoming accelerometer data starts with the letter G,
-followed by 3 16-bit little-endian numbers.
+Starts a stream of accelerometer data. Will send constantly until stop command
+is sent. Incoming accelerometer data starts with the letter G, followed by 3
+16-bit little-endian numbers.
 
 _Availability:_ Max, Nora
 
 _Command Format_
+
 ```
 StartMove:1;
 ```
 
 _Return Example_
+
 ```
 GEF008312ED00;
 ```
@@ -381,11 +403,13 @@ Stops stream of accelerometer data.
 _Availability:_ Max, Nora
 
 _Command Format_
+
 ```
 StopMove:1;
 ```
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -397,11 +421,13 @@ Changes the direction of rotation for the toy.
 _Availability:_ Nora
 
 _Command Format_
+
 ```
 RotateChange;
 ```
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -413,6 +439,7 @@ Changes the rotation speed of the Nora toy. Takes integer values from 0-20.
 _Availability_: Nora
 
 _Command Format_
+
 ```
 Rotate:10;
 ```
@@ -420,6 +447,7 @@ Rotate:10;
 Sets rotation speed to 10 (50%).
 
 _Return Example_
+
 ```
 OK;
 ```
@@ -431,6 +459,7 @@ Changes the inflation level of the Max toy. Takes integer values from 0-5.
 _Availability:_ Max
 
 _Command Format_
+
 ```
 Air:Level:3;
 ```
@@ -438,18 +467,20 @@ Air:Level:3;
 Sets air level to 3 (60%).
 
 _Return Example_
+
 ```
 OK;
 ```
 
 #### Set Relative Inflation Level
 
-Inflates relative to current level, i.e. if currently inflation level
-is 3, and "Air:In:1;" is sent, will inflate to 4.
+Inflates relative to current level, i.e. if currently inflation level is 3, and
+"Air:In:1;" is sent, will inflate to 4.
 
 _Availability:_ Max
 
 _Command Format_
+
 ```
 Air:In:1;
 ```
@@ -457,18 +488,20 @@ Air:In:1;
 Sets air level to 1 level more inflated than it was.
 
 _Return Example_
+
 ```
 OK;
 ```
 
 #### Set Relative Deflation Level
 
-Deflates relative to current level, i.e. if currently inflation level
-is 3, and "Air:Out:1;" is sent, will deflate to 2.
+Deflates relative to current level, i.e. if currently inflation level is 3, and
+"Air:Out:1;" is sent, will deflate to 2.
 
 _Availability:_ Max
 
 _Command Format_
+
 ```
 Air:Out:1;
 ```
@@ -476,71 +509,75 @@ Air:Out:1;
 Sets air level to 1 level deflated than it was.
 
 _Return Example_
+
 ```
 OK;
 ```
 
 #### Get Production Batch Number
 
-Returns the production batch number for this device.
-This digits appear to correspond to a `YYMMDD` date during manufacture.
+Returns the production batch number for this device. This digits appear to
+correspond to a `YYMMDD` date during manufacture.
 
 _Availability:_ All toys? Confirmed: Lush 2, Hush, Domi.
 
 _Command Format_
+
 ```
 GetBatch;
 ```
 
 _Return Example_
+
 ```
 190124;
 ```
 
 #### Count Programmed Patterns
 
-List the indexes of the patterns that are currently programmed into
-the device. The maximum number of patterns in 10, so each index will
-always be a single digit.
+List the indexes of the patterns that are currently programmed into the device.
+The maximum number of patterns in 10, so each index will always be a single
+digit.
 
 _Availability:_ Lush 2, Domi
 
 _Command Format_
+
 ```
 GetPatten;
 ```
 
 _Return Example_
+
 ```
 P:01234;
 ```
 
-This return tells us that there are currently five patterns programmed
-on the device, with indicies 0 through 4.
+This return tells us that there are currently five patterns programmed on the
+device, with indicies 0 through 4.
 
 #### View Programmed Pattern
 
 Returns a pattern that is currently programmed into the device.
 
-Each pattern is represented as a series of digits from 0 to 9, each
-indicating the vibration level for one half-second of the pattern.
-(This is different than the 0-20 scale used by the Vibrate command.)
+Each pattern is represented as a series of digits from 0 to 9, each indicating
+the vibration level for one half-second of the pattern. (This is different than
+the 0-20 scale used by the Vibrate command.)
 
-The response is split into multiple messages, each containing up to
-12 digits (6 seconds). Each response has a prefix indicating the
-pattern index, the number of parts in the response, and the index of
-the response.
+The response is split into multiple messages, each containing up to 12 digits (6
+seconds). Each response has a prefix indicating the pattern index, the number of
+parts in the response, and the index of the response.
 
-For the Domi, the pattern length must be between 5 and 50 seconds, so
-the response will use a maximum of 9 messages, so the part count and
-indicies will always be a single digit.
+For the Domi, the pattern length must be between 5 and 50 seconds, so the
+response will use a maximum of 9 messages, so the part count and indicies will
+always be a single digit.
 
-For the Lush 2, the part count and indicies are padded to always use
-two digits.
+For the Lush 2, the part count and indicies are padded to always use two digits.
 
 _Availability:_ Lush 2, Domi
 
 _Command Format_
+
 ```
 GetPatten:4;
 ```
@@ -548,6 +585,7 @@ GetPatten:4;
 Domi response using one-digit part indices:
 
 _Return Example_
+
 ```
 P4:1/5:000042003720;
 P4:2/5:000002436658;
@@ -559,40 +597,50 @@ P4:5/5:1110000000;
 Lush 2 response using two-digit part indices:
 
 _Return Example_
+
 ```
 P4:01/01:346797643;
 ```
 
 #### Run Programmed Patern
 
-Starts running a programmed pattern on a loop. Takes an positive
-integer pattern index to start running it, or 0 to stop running the pattern.
+Starts running a programmed pattern on a loop. Takes an positive integer pattern
+index to start running it, or 0 to stop running the pattern.
 
-While Domi is able to take any pattern index, from 0 to 10, Lush 2 only seems
-to be able to take indices from 0 to 4. Other toys have not been tested.
+While Domi is able to take any pattern index, from 0 to 10, Lush 2 only seems to
+be able to take indices from 0 to 4. Other toys have not been tested.
 
 _Availability:_ Lush, Hush, Ambi, Domi, Edge, Osci
 
 _Command Format_
+
 ```
 Preset:8;
 ```
 
 _Return Example_
+
 ```
 OK;
 ```
 
 ## Related Projects and Links
 
-The applications and repositories below contain implementations of the
-Lovense communications protocol, or have relevant information about
-the hardware/firmware.
+The applications and repositories below contain implementations of the Lovense
+communications protocol, or have relevant information about the
+hardware/firmware.
 
-* Buttplug C# (All toys): [https://github.com/metafetish/buttplug-csharp](https://github.com/metafetish/buttplug-csharp)
-* Buttplug JS (All toys): [https://github.com/metafetish/buttplug-js](https://github.com/metafetish/buttplug-js)
-* lovesense-rs (Rust, Max/Nora only): [https://github.com/metafetish/lovesense-rs](https://github.com/metafetish/lovesense-rs)
-* lovesense-py (Python, Max/Nora only): [https://github.com/metafetish/lovesense-py](https://github.com/metafetish/lovesense-py)
-* Max/MSP patch (Max/MSP, Max/Nora only): [https://github.com/metafetish/lovesense-max](https://github.com/metafetish/lovesense-max)
-* Node.js Library (Max/Nora only): [https://github.com/metafetish/lovesense-js](https://github.com/metafetish/lovesense-js)
-* WebBluetooth JS Library/Demo (Hush only): [https://github.com/metafetish/lovesense-hush-js-demo](https://github.com/metafetish/lovesense-hush-js-demo)
+- Buttplug C# (All toys):
+  [https://github.com/metafetish/buttplug-csharp](https://github.com/metafetish/buttplug-csharp)
+- Buttplug JS (All toys):
+  [https://github.com/metafetish/buttplug-js](https://github.com/metafetish/buttplug-js)
+- lovesense-rs (Rust, Max/Nora only):
+  [https://github.com/metafetish/lovesense-rs](https://github.com/metafetish/lovesense-rs)
+- lovesense-py (Python, Max/Nora only):
+  [https://github.com/metafetish/lovesense-py](https://github.com/metafetish/lovesense-py)
+- Max/MSP patch (Max/MSP, Max/Nora only):
+  [https://github.com/metafetish/lovesense-max](https://github.com/metafetish/lovesense-max)
+- Node.js Library (Max/Nora only):
+  [https://github.com/metafetish/lovesense-js](https://github.com/metafetish/lovesense-js)
+- WebBluetooth JS Library/Demo (Hush only):
+  [https://github.com/metafetish/lovesense-hush-js-demo](https://github.com/metafetish/lovesense-hush-js-demo)

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -127,6 +127,9 @@ Denotes Nora toy, running v1.1 firmware, BT Addr of 00:82:05:9A:D3:BD
 
 Returns the battery level of the toy as an integer percentage from 0-100.
 
+Some toys will prepend an `s` character (such as `s99`) to indicate that when
+they are active (i.e. when a vibrator motor is turned on).
+
 _Availability:_ All toys
 
 _Command Format_

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -6,43 +6,42 @@ Lovense has been manufacturing toys since 2011.
 
 ## Bluetooth Details
 
-While all Lovense toys use the same protocol, they can communicate
-over Bluetooth differently, depending on when they were released.
+While all Lovense toys use the same protocol, they can communicate over
+Bluetooth differently, depending on when they were released.
 
 ### Bluetooth 2.0 Toys
 
-The first toys released by Lovense used both Bluetooth 2.0 SPP
-(emulating a serial port) and Bluetooth LE. This was most likely due
-to the sparse mobile support of BTLE when they were released.
+The first toys released by Lovense used both Bluetooth 2.0 SPP (emulating a
+serial port) and Bluetooth LE. This was most likely due to the sparse mobile
+support of BTLE when they were released.
 
 These toys include:
 
 - Max
 - Nora
 
-When paired with a system via Bluetooth 2.0, these toys identify as a
-serial port. These toys are also capable of using Bluetooth 4.0, as
-outlined in the next section.
+When paired with a system via Bluetooth 2.0, these toys identify as a serial
+port. These toys are also capable of using Bluetooth 4.0, as outlined in the
+next section.
 
 ### Bluetooth LE Toys
 
-Starting with the Lush, all toys released by Lovense use only
-Bluetooth LE.
+Starting with the Lush, all toys released by Lovense use only Bluetooth LE.
 
-These toys have GATT characteristics to mimic the RX/TX setup of the
-serial port style control of the old toys. The GATT service and
-characteristic IDs differ between different toy firmware versions.
+These toys have GATT characteristics to mimic the RX/TX setup of the serial port
+style control of the old toys. The GATT service and characteristic IDs differ
+between different toy firmware versions.
 
-It's difficult to keep a current list of exact Lovense device names
-and service/characteristic UUIDs, as they tend to change rapidly on
-firmware updates. The following rules can be used for finding and
-connecting to Lovense toys.
+It's difficult to keep a current list of exact Lovense device names and
+service/characteristic UUIDs, as they tend to change rapidly on firmware
+updates. The following rules can be used for finding and connecting to Lovense
+toys.
 
-Lovense toy names always start with "LVS-". What comes after that
-varies depending on when the toy was released. Early toys used names
-involving the single character identifier, like "LVS-A011", while
-newer toys use the full product name, like "LVS-Edge36". The last 2
-numbers denote the firmware version the toy is running.
+Lovense toy names always start with "LVS-". What comes after that varies
+depending on when the toy was released. Early toys used names involving the
+single character identifier, like "LVS-A011", while newer toys use the full
+product name, like "LVS-Edge36". The last 2 numbers denote the firmware version
+the toy is running.
 
 Lovense toys usually have one of 3 service ID formats:
 
@@ -52,50 +51,48 @@ Lovense toys usually have one of 3 service ID formats:
 XY300001-002Z-4bd4-bbd5-a6920e4c5653
 ```
 
-The first two service IDs are static, and represent the service IDs
-used by first and second generation Lovense toys. The 3rd service ID
-can vary, with
+The first two service IDs are static, and represent the service IDs used by
+first and second generation Lovense toys. The 3rd service ID can vary, with
 
 - X usually being 0x4 or 0x5
 - Y being any number 0x0-0xf
 - Z usually being 0x3 or 0x4
 
-While some Bluetooth APIs can wildcard services, others like
-WebBluetooth require an exact service UUID to connect. For these
-instances, it's recommended to just generate out all 32 variations of
-the last service, for a total of 34 services, to use with the
-optionalServices portion of a WebBluetooth connection filter.
+While some Bluetooth APIs can wildcard services, others like WebBluetooth
+require an exact service UUID to connect. For these instances, it's recommended
+to just generate out all 32 variations of the last service, for a total of 34
+services, to use with the optionalServices portion of a WebBluetooth connection
+filter.
 
-To identify the type of toy after connecting, it is recommended to use
-the [DeviceType;](lovense.md#get-device-information) message, outlined
-below. This will return a device model identifier.
+To identify the type of toy after connecting, it is recommended to use the
+[DeviceType;](lovense.md#get-device-information) message, outlined below. This
+will return a device model identifier.
 
 ## Protocol
 
 Commands for Lovense toys follows these rules:
 
 - Commands and replies are strings, using semicolons to mark their end.
-- All commands start with a command identifier word, then possibly
-  either specifiers or levels, delimited by colons. e.g. "Vibrate:5;"
-  would set vibration to 5.
-- Replies are in the context of the command (i.e. sending "Battery;"
-  will just return a number, like "85;"), but can still be colon
-  delimited lists.
-- Commands that do not return a context specific value will return
-  "OK;" on success, "ERR;" on error.
+- All commands start with a command identifier word, then possibly either
+  specifiers or levels, delimited by colons. e.g. "Vibrate:5;" would set
+  vibration to 5.
+- Replies are in the context of the command (i.e. sending "Battery;" will just
+  return a number, like "85;"), but can still be colon delimited lists.
+- Commands that do not return a context specific value will return "OK;" on
+  success, "ERR;" on error.
 
 ### Command List
 
-The following is the known command table for all toys. Anything send or
-received over the serial port is in quotes to denote communication, but
-should not be sent using quotes if you are implementing your own version
-of this protocol. Commands with ":x" mean that the x should be replaced
-with a number, the range of which is mentioned in the description.
+The following is the known command table for all toys. Anything send or received
+over the serial port is in quotes to denote communication, but should not be
+sent using quotes if you are implementing your own version of this protocol.
+Commands with ":x" mean that the x should be replaced with a number, the range
+of which is mentioned in the description.
 
 #### Get Device Information
 
-Returns toy model type, firmware version, and Bluetooth MAC address,
-as a colon delimited list
+Returns toy model type, firmware version, and Bluetooth MAC address, as a colon
+delimited list
 
 _Availability:_ All toys
 
@@ -111,7 +108,8 @@ _Return Example_
 C:11:0082059AD3BD;
 ```
 
-Denotes Nora toy, running v1.1 firmware, with a Bluetooth address of 00:82:05:9A:D3:BD
+Denotes Nora toy, running v1.1 firmware, with a Bluetooth address of
+00:82:05:9A:D3:BD
 
 **Model Types:**
 
@@ -169,7 +167,7 @@ OK;
 
 Retreive the status of the toy.
 
-_Availability:_ All toys
+_Availability:_ Most toys (confirmed unsupported: Quake)
 
 _Command Format_
 
@@ -207,10 +205,14 @@ _Return Example_
 OK;
 ```
 
+For toys with two vibrators, this command may be used to control both of them
+together, or the `Vibrate1` and `Vibrate2` variants may be used to control them
+independently.
+
 #### Configure Toy Settings
 
-There are settings configurable through the Lovense Remote
-application which have read and write commands.
+There are settings configurable through the Lovense Remote application which
+have read and write commands.
 
 ##### AutoSwith
 
@@ -239,8 +241,7 @@ _Return Example_
 AutoSwith:0:1;
 ```
 
-Indicates "turn off on disconnect" disabled;
-"last level on reconnect" enabled.
+Indicates "turn off on disconnect" disabled; "last level on reconnect" enabled.
 
 _Command Format_
 
@@ -258,8 +259,8 @@ OK;
 
 ##### Light
 
-Labelled "Enable/Disable LED" in Lovense Remote. Not shown
-in Lovense Remote for Domi.
+Labelled "Enable/Disable LED" in Lovense Remote. Not shown in Lovense Remote for
+Domi.
 
 Controls power/connection LED.
 
@@ -341,11 +342,11 @@ OK;
 
 #### Preset Levels
 
-The Domi allows customization of the low, medium, and high levels
-selectable using the hardware buttons. The raw levels are the
-same integer values used for the Vibrate command.
+The Domi allows customization of the low, medium, and high levels selectable
+using the hardware buttons. The raw levels are the same integer values used for
+the Vibrate command.
 
-_Availability:_ Domi
+_Availability:_ Domi, Quake
 
 _Command Format_
 
@@ -361,8 +362,8 @@ _Return Example_
 1,9,20;
 ```
 
-Vibration levels. Indicates 1 for low, 9 for medium, 20 for high.
-This is the factory default.
+Vibration levels. Indicates 1 for low, 9 for medium, 20 for high. This is the
+factory default.
 
 _Command Format_
 
@@ -370,8 +371,8 @@ _Command Format_
 SetLevel:3:16;
 ```
 
-Set High to level 16. 1, 2, and 3 as the first argument refer to
-low, medium, and high, respectively.
+Set High to level 16. 1, 2, and 3 as the first argument refer to low, medium,
+and high, respectively.
 
 _Return Example_
 
@@ -381,9 +382,9 @@ OK;
 
 #### Start Accelerometer Data Stream
 
-Starts a stream of accelerometer data. Will send constantly until stop
-command is sent. Incoming accelerometer data starts with the letter G,
-followed by 3 16-bit little-endian numbers.
+Starts a stream of accelerometer data. Will send constantly until stop command
+is sent. Incoming accelerometer data starts with the letter G, followed by 3
+16-bit little-endian numbers.
 
 _Availability:_ Max, Nora
 
@@ -479,8 +480,8 @@ OK;
 
 #### Set Relative Inflation Level
 
-Inflates relative to current level, i.e. if currently inflation level
-is 3, and "Air:In:1;" is sent, will inflate to 4.
+Inflates relative to current level, i.e. if currently inflation level is 3, and
+"Air:In:1;" is sent, will inflate to 4.
 
 _Availability:_ Max
 
@@ -500,8 +501,8 @@ OK;
 
 #### Set Relative Deflation Level
 
-Deflates relative to current level, i.e. if currently inflation level
-is 3, and "Air:Out:1;" is sent, will deflate to 2.
+Deflates relative to current level, i.e. if currently inflation level is 3, and
+"Air:Out:1;" is sent, will deflate to 2.
 
 _Availability:_ Max
 
@@ -521,8 +522,8 @@ OK;
 
 #### Get Production Batch Number
 
-Returns the production batch number for this device.
-This digits appear to correspond to a `YYMMDD` date during manufacture.
+Returns the production batch number for this device. This digits appear to
+correspond to a `YYMMDD` date during manufacture.
 
 _Availability:_ All toys? Confirmed: Lush 2, Hush, Domi, Quake.
 
@@ -540,9 +541,9 @@ _Return Example_
 
 #### Count Programmed Patterns
 
-List the indexes of the patterns that are currently programmed into
-the device. The maximum number of patterns in 10, so each index will
-always be a single digit.
+List the indexes of the patterns that are currently programmed into the device.
+The maximum number of patterns in 10, so each index will always be a single
+digit.
 
 _Availability:_ Lush 2, Domi
 
@@ -558,30 +559,28 @@ _Return Example_
 P:01234;
 ```
 
-This return tells us that there are currently five patterns programmed
-on the device, with indicies 0 through 4.
+This return tells us that there are currently five patterns programmed on the
+device, with indicies 0 through 4.
 
 #### View Programmed Pattern
 
 Returns a pattern that is currently programmed into the device.
 
-Each pattern is represented as a series of digits from 0 to 9, each
-indicating the vibration level for one half-second of the pattern.
-(This is different than the 0-20 scale used by the Vibrate command.)
+Each pattern is represented as a series of digits from 0 to 9, each indicating
+the vibration level for one half-second of the pattern. (This is different than
+the 0-20 scale used by the Vibrate command.)
 
-The response is split into multiple messages, each containing up to
-12 digits (6 seconds). Each response has a prefix indicating the
-pattern index, the number of parts in the response, and the index of
-the response.
+The response is split into multiple messages, each containing up to 12 digits (6
+seconds). Each response has a prefix indicating the pattern index, the number of
+parts in the response, and the index of the response.
 
-For the Domi, the pattern length must be between 5 and 50 seconds, so
-the response will use a maximum of 9 messages, so the part count and
-indicies will always be a single digit.
+For the Domi, the pattern length must be between 5 and 50 seconds, so the
+response will use a maximum of 9 messages, so the part count and indicies will
+always be a single digit.
 
-For the Lush 2, the part count and indicies are padded to always use
-two digits.
+For the Lush 2, the part count and indicies are padded to always use two digits.
 
-_Availability:_ Lush 2, Domi
+_Availability:_ Lush 2, Domi, Quake
 
 _Command Format_
 
@@ -611,13 +610,14 @@ P4:01/01:346797643;
 
 #### Run Programmed Patern
 
-Starts running a programmed pattern on a loop. Takes an positive
-integer pattern index to start running it, or 0 to stop running the pattern.
+Starts running a programmed pattern on a loop. Takes an positive integer pattern
+index to start running it, or 0 to stop running the pattern.
 
-While Domi is able to take any pattern index, from 0 to 10, Lush 2 only seems
-to be able to take indices from 0 to 4. Other toys have not been tested.
+While Domi is able to take any pattern index, from 0 to 10, Lush 2 and Quake
+only seem to be able to take indices from 0 to 4. Other toys have not been
+tested.
 
-_Availability:_ Lush, Hush, Ambi, Domi, Edge, Osci
+_Availability:_ Lush, Hush, Ambi, Domi, Edge, Osci, Quake
 
 _Command Format_
 
@@ -633,14 +633,21 @@ OK;
 
 ## Related Projects and Links
 
-The applications and repositories below contain implementations of the
-Lovense communications protocol, or have relevant information about
-the hardware/firmware.
+The applications and repositories below contain implementations of the Lovense
+communications protocol, or have relevant information about the
+hardware/firmware.
 
-- Buttplug C# (All toys): [https://github.com/metafetish/buttplug-csharp](https://github.com/metafetish/buttplug-csharp)
-- Buttplug JS (All toys): [https://github.com/metafetish/buttplug-js](https://github.com/metafetish/buttplug-js)
-- lovesense-rs (Rust, Max/Nora only): [https://github.com/metafetish/lovesense-rs](https://github.com/metafetish/lovesense-rs)
-- lovesense-py (Python, Max/Nora only): [https://github.com/metafetish/lovesense-py](https://github.com/metafetish/lovesense-py)
-- Max/MSP patch (Max/MSP, Max/Nora only): [https://github.com/metafetish/lovesense-max](https://github.com/metafetish/lovesense-max)
-- Node.js Library (Max/Nora only): [https://github.com/metafetish/lovesense-js](https://github.com/metafetish/lovesense-js)
-- WebBluetooth JS Library/Demo (Hush only): [https://github.com/metafetish/lovesense-hush-js-demo](https://github.com/metafetish/lovesense-hush-js-demo)
+- Buttplug C# (All toys):
+  [https://github.com/metafetish/buttplug-csharp](https://github.com/metafetish/buttplug-csharp)
+- Buttplug JS (All toys):
+  [https://github.com/metafetish/buttplug-js](https://github.com/metafetish/buttplug-js)
+- lovesense-rs (Rust, Max/Nora only):
+  [https://github.com/metafetish/lovesense-rs](https://github.com/metafetish/lovesense-rs)
+- lovesense-py (Python, Max/Nora only):
+  [https://github.com/metafetish/lovesense-py](https://github.com/metafetish/lovesense-py)
+- Max/MSP patch (Max/MSP, Max/Nora only):
+  [https://github.com/metafetish/lovesense-max](https://github.com/metafetish/lovesense-max)
+- Node.js Library (Max/Nora only):
+  [https://github.com/metafetish/lovesense-js](https://github.com/metafetish/lovesense-js)
+- WebBluetooth JS Library/Demo (Hush only):
+  [https://github.com/metafetish/lovesense-hush-js-demo](https://github.com/metafetish/lovesense-hush-js-demo)

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -206,6 +206,27 @@ _Return Example_
 OK;
 ```
 
+#### Set Specific Vibrator's Speed
+
+Changes the vibration speed for a specific vibrator in the toy. Takes a vibrator
+index `1` or `2` and an integer vibration speed from 0-20.
+
+_Availability:_ Edge, Quake
+
+_Command Format_
+
+```
+Vibrate1:5;
+```
+
+Sets the speed of vibrator 1 to 5 (25%).
+
+_Return Example_
+
+```
+Vibrate1:5;
+```
+
 #### Configure Toy Settings
 
 There are settings configurable through the Lovense Remote application which

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -123,6 +123,7 @@ Denotes Nora toy, running v1.1 firmware, BT Addr of 00:82:05:9A:D3:BD
 | Domi | W |
 | Edge | P |
 | Osci | O |
+| Quake | J |
 
 
 #### Get Battery Level
@@ -485,7 +486,7 @@ OK;
 Returns the production batch number for this device.
 This digits appear to correspond to a `YYMMDD` date during manufacture.
 
-_Availability:_ All toys? Confirmed: Lush 2, Hush, Domi.
+_Availability:_ All toys? Confirmed: Lush 2, Hush, Domi, Quake.
 
 _Command Format_
 ```

--- a/stpihkal/protocols/lovense.md
+++ b/stpihkal/protocols/lovense.md
@@ -6,8 +6,8 @@ Lovense has been manufacturing toys since 2011.
 
 ## Bluetooth Details
 
-While all lovense toys use the same protocol, they can communicate
-over bluetooth differently, depending on when they were released.
+While all Lovense toys use the same protocol, they can communicate
+over Bluetooth differently, depending on when they were released.
 
 ### Bluetooth 2.0 Toys
 
@@ -60,7 +60,7 @@ can vary, with
 - Y being any number 0x0-0xf
 - Z usually being 0x3 or 0x4
 
-While some bluetooth APIs can wildcard services, others like
+While some Bluetooth APIs can wildcard services, others like
 WebBluetooth require an exact service UUID to connect. For these
 instances, it's recommended to just generate out all 32 variations of
 the last service, for a total of 34 services, to use with the
@@ -94,7 +94,7 @@ with a number, the range of which is mentioned in the description.
 
 #### Get Device Information
 
-Returns toy model type, firmware version, and bluetooth MAC address,
+Returns toy model type, firmware version, and Bluetooth MAC address,
 as a colon delimited list
 
 _Availability:_ All toys
@@ -161,7 +161,7 @@ OK;
 
 #### Device Status
 
-Retreive the status of the toy. 
+Retreive the status of the toy.
 
 _Availability:_ All toys
 
@@ -199,15 +199,15 @@ OK;
 
 #### Configure Toy Settings
 
-There are settings configurable through the Lovense Remote 
-application which have read and write commands. 
+There are settings configurable through the Lovense Remote
+application which have read and write commands.
 
 ##### AutoSwith
 
 Configures options labelled as follows in Lovense Remote:
 
-- Turn off the toy when there is an accidental bluetooth disconnection
-- Toy will go to last level when it reconnects 
+- Turn off the toy when there is an accidental Bluetooth disconnection
+- Toy will go to last level when it reconnects
 
 Note both options are marked Beta. "Turn off" appears to mean disable vibration.
 
@@ -227,7 +227,7 @@ _Return Example_
 AutoSwith:0:1;
 ```
 
-Indicates "turn off on disconnect" disabled; 
+Indicates "turn off on disconnect" disabled;
 "last level on reconnect" enabled.
 
 _Command Format_
@@ -319,8 +319,8 @@ OK;
 
 #### Preset Levels
 
-The Domi allows customization of the low, medium, and high levels 
-selectable using the hardware buttons. The raw levels are the 
+The Domi allows customization of the low, medium, and high levels
+selectable using the hardware buttons. The raw levels are the
 same integer values used for the Vibrate command.
 
 _Availability:_ Domi
@@ -337,7 +337,7 @@ _Return Example_
 1,9,20;
 ```
 
-Vibration levels. Indicates 1 for low, 9 for medium, 20 for high. 
+Vibration levels. Indicates 1 for low, 9 for medium, 20 for high.
 This is the factory default.
 
 _Command Format_
@@ -345,7 +345,7 @@ _Command Format_
 SetLevel:3:16;
 ```
 
-Set High to level 16. 1, 2, and 3 as the first argument refer to 
+Set High to level 16. 1, 2, and 3 as the first argument refer to
 low, medium, and high, respectively.
 
 _Return Example_


### PR DESCRIPTION
The Lovense documentation has become a bit cluttered as information for additional devices has been added. This preserves most of the substance, but restructures it to be a bit clearer, with a device-command compatibility matrix near the beginning, the introduction focused a bit more on the high-level behaviour than the historical implementation details, and less clutter in the individual command descriptions.